### PR TITLE
Allow supply update changes.

### DIFF
--- a/FerngillSimpleEconomy/handlers/DayEndHandler.cs
+++ b/FerngillSimpleEconomy/handlers/DayEndHandler.cs
@@ -12,7 +12,6 @@ public class DayEndHandler(
 	IEconomyService economyService)
 	: IHandler
 {
-	private const int LastDayOfMonth = 28;
 
 	public void Register()
 	{
@@ -50,16 +49,13 @@ public class DayEndHandler(
 
 	private void HandleEndOfSeason()
 	{
-		if (Game1.dayOfMonth < LastDayOfMonth)
-		{
-			return;
-		}
-
-		if (Utility.getSeasonNumber(Game1.currentSeason) == 3)
+		if (economyService.UpdateSupplyYear)
 		{
 			economyService.SetupForNewYear();
+			return; // Skip seasonal update if yearly is happening.
 		}
-		else
+
+		if (economyService.UpdateSupplySeason)
 		{
 			economyService.SetupForNewSeason();
 		}

--- a/FerngillSimpleEconomy/handlers/GameLoadedHandler.cs
+++ b/FerngillSimpleEconomy/handlers/GameLoadedHandler.cs
@@ -194,7 +194,25 @@ public class GameLoadedHandler(
 			getValue: () => ConfigModel.Instance.DisableArtisanMapping,
 			setValue: val => ConfigModel.Instance.DisableArtisanMapping = val
 		);
-			
+
+		configMenu.AddTextOption( // Seasonal supply
+			mod: manifest,
+			name: () => helper.Translation.Get("fse.config.ChangeFreq"),
+			getValue: () => ConfigModel.Instance.ChangeFreq.ToString(),
+			setValue: val => ConfigModel.Instance.ChangeFreq = System.Enum.Parse<ConfigModel.Frequency>(val),
+			allowedValues: ["FreqDay", "FreqWeek", "FreqSeason", "FreqYear"],
+			formatAllowedValue: val => helper.Translation.Get($"fse.config.{val}")
+		);
+
+		configMenu.AddTextOption( // Yearly supply
+			mod: manifest,
+			name: () => helper.Translation.Get("fse.config.SupplyFreq"),
+			getValue: () => ConfigModel.Instance.SupplyFreq.ToString(),
+			setValue: val => ConfigModel.Instance.SupplyFreq = System.Enum.Parse<ConfigModel.Frequency>(val),
+			allowedValues: ["FreqDay", "FreqWeek", "FreqSeason", "FreqYear"],
+			formatAllowedValue: val => helper.Translation.Get($"fse.config.{val}")
+		);
+
 		configMenu.AddKeybindList(
 			mod: manifest,
 			name: ()=> helper.Translation.Get("fse.config.hotkey.openMenu"),

--- a/FerngillSimpleEconomy/i18n/default.json
+++ b/FerngillSimpleEconomy/i18n/default.json
@@ -36,5 +36,11 @@
 	"fse.config.hotkey.openMenu": "Open Forecast",
 	"fse.config.Reset": "Reset",
 	"fse.config.category.header": "Categories in Economy",
-	"fse.config.category.subtitle": "The game must be restarted after this is changed. Names may appear duplicated as that is how the game references them. Check the wiki for specifics."
+	"fse.config.category.subtitle": "The game must be restarted after this is changed. Names may appear duplicated as that is how the game references them. Check the wiki for specifics.",
+	"fse.config.ChangeFreq": "Seasonal supply update frequency.",
+	"fse.config.SupplyFreq": "Yearly supply update frequency.",
+	"fse.config.FreqDay": "Daily",
+	"fse.config.FreqWeek": "Weekly",
+	"fse.config.FreqSeason": "Seasonally",
+	"fse.config.FreqYear": "Yearly"
 }

--- a/FerngillSimpleEconomy/models/ConfigModel.cs
+++ b/FerngillSimpleEconomy/models/ConfigModel.cs
@@ -9,7 +9,8 @@ public class ConfigModel
 	public static ConfigModel Instance { get; set; } = new();
 	public const int MinSupply = 0;
 	public const int MaxSupply = int.MaxValue;
-	
+	public enum Frequency { FreqDay, FreqWeek, FreqSeason, FreqYear }
+
 	public int MaxCalculatedSupply { get; set; } = 1000;
 	public int MinDelta { get; set; } = -30;
 	public int MaxDelta { get; set; } = 30;
@@ -25,6 +26,8 @@ public class ConfigModel
 	public bool EnableShopDisplay { get; set; } = true;
 	public bool EnableTooltip { get; set; } = true;
 	public bool DisableArtisanMapping { get; set; } = false;
+	public Frequency ChangeFreq { get; set; } = Frequency.FreqSeason; // Seasonal supply
+	public Frequency SupplyFreq { get; set; } = Frequency.FreqYear; // Yearly supply
 	public KeybindList ShowMenuHotkey { get; set; } = KeybindList.Parse("H");
 
 	public List<int> ValidCategories { get; set; } =


### PR DESCRIPTION
Allows you to set the frequency of seasonal and annual supply amount updates to daily, weekly, seasonally, or yearly. Would resolve paulsteele/Ferngill-Supply-And-Demand#30.

Also adds the settings to the config/options and adds the relevant localization strings to the default i18n file (but not the others).