### PR TITLE
Added Instant Price and Supply calculation

### DIFF
--- a/FerngillSimpleEconomy/handlers/DayEndHandler.cs
+++ b/FerngillSimpleEconomy/handlers/DayEndHandler.cs
@@ -1,4 +1,5 @@
-﻿using fse.core.actions;
+﻿// DayEndHandler.cs
+using fse.core.actions;
 using fse.core.helpers;
 using fse.core.models;
 using fse.core.services;
@@ -11,17 +12,20 @@ using static fse.core.models.ConfigModel;
 namespace fse.core.handlers;
 
 public class DayEndHandler(
-	IModHelper helper,
-	IMonitor monitor,
-	IEconomyService economyService)
-	: IHandler
-{
+		IModHelper helper,
+		IMonitor monitor,
+		IEconomyService economyService
+) : IHandler {
+
+	private readonly Dictionary<string, int> _pendingAdjust = new();
+
 	public void Register()
 	{
-		helper.Events.GameLoop.DayEnding += (_, _) => 
-			SafeAction.Run(GameLoopOnDayEnding, monitor, nameof(GameLoopOnDayEnding));
+		helper.Events.GameLoop.DayEnding += (_, _) =>
+				SafeAction.Run(GameLoopOnDayEnding, monitor, nameof(GameLoopOnDayEnding));
+
 		helper.Events.GameLoop.DayStarted += (_, _) =>
-			SafeAction.Run(economyService.AdvanceOneDay, monitor, nameof(economyService.AdvanceOneDay));
+				SafeAction.Run(OnDayStarted, monitor, nameof(OnDayStarted));
 	}
 
 	private void GameLoopOnDayEnding()
@@ -33,44 +37,44 @@ public class DayEndHandler(
 		if (!Game1.player.team.useSeparateWallets.Value)
 			farmers = [farmers.First()];
 
-		if (ConfigModel.Instance.ShippingPricingMode == PricingMode.Instant)
-		{
-			var qtyByModel = new Dictionary<ItemModel, int>();
-			foreach (var farmer in farmers)
+		foreach (var farmer in farmers) {
+			foreach (var item in Game1.getFarm().getShippingBin(farmer))
 			{
-				foreach (var it in Game1.getFarm().getShippingBin(farmer))
+				if (item is not Object o) continue;
+
+				if (ConfigModel.Instance.ShippingPricingMode == PricingMode.Instant)
 				{
-					if (it is not Object o) continue;
 					var model = economyService.GetItemModelFromObject(o);
 					if (model is null) continue;
-					qtyByModel[model] = qtyByModel.TryGetValue(model, out var q) ? q + o.Stack : o.Stack;
+
+					// Add Shipped Items (via Shipping Bin)
+					_pendingAdjust[model.ObjectId] =
+							_pendingAdjust.TryGetValue(model.ObjectId, out var q) ? q + o.Stack : o.Stack;
 				}
-			}
-
-			foreach (var kv in qtyByModel)
-			{
-				var model = kv.Key;
-				var qty = kv.Value;
-				if (qty <= 0) continue;
-
-				var startSupply = model.Supply;
-				decimal sum = 0m;
-				for (int i = 1; i <= qty; i++)
-					sum += model.GetMultiplierAtSupply(startSupply + i);
-
-				var avg = sum / qty;
-				model.SetOneNightOverrideMultiplier(avg);
-			}
-		}
-
-		foreach (var farmer in farmers)
-		{
-			foreach (var item in Game1.getFarm().getShippingBin(farmer).Where(item => item is Object))
-			{
-				economyService.AdjustSupply(item as Object, item.Stack, false);
+				else
+				{
+					// Default Behaviour
+					economyService.AdjustSupply(o, o.Stack, notifyPeers: false);
+				}
 			}
 		}
 
 		economyService.HandleDayEnd(new DayModel(Game1.year, SeasonHelper.GetCurrentSeason(), Game1.dayOfMonth));
+	}
+
+	private void OnDayStarted()
+	{
+		// Add "Supply" to Shipped Items (via Shipping Bin)
+		if (_pendingAdjust.Count > 0)
+		{
+			foreach (var (objectId, qty) in _pendingAdjust)
+			{
+				economyService.AdjustSupply(new Object(objectId, 1), qty, notifyPeers: false);
+			}
+
+			_pendingAdjust.Clear();
+		}
+
+		economyService.AdvanceOneDay();
 	}
 }

--- a/FerngillSimpleEconomy/handlers/DayEndHandler.cs
+++ b/FerngillSimpleEconomy/handlers/DayEndHandler.cs
@@ -1,10 +1,12 @@
-﻿using System.Linq;
-using fse.core.actions;
+﻿using fse.core.actions;
 using fse.core.helpers;
 using fse.core.models;
 using fse.core.services;
 using StardewModdingAPI;
 using StardewValley;
+using System.Collections.Generic;
+using System.Linq;
+using static fse.core.models.ConfigModel;
 
 namespace fse.core.handlers;
 
@@ -25,22 +27,46 @@ public class DayEndHandler(
 	private void GameLoopOnDayEnding()
 	{
 		if (!Game1.player.IsMainPlayer)
-		{
 			return;
-		}
 
 		var farmers = Game1.getAllFarmers();
-
 		if (!Game1.player.team.useSeparateWallets.Value)
-		{
 			farmers = [farmers.First()];
+
+		if (ConfigModel.Instance.ShippingPricingMode == PricingMode.Instant)
+		{
+			var qtyByModel = new Dictionary<ItemModel, int>();
+			foreach (var farmer in farmers)
+			{
+				foreach (var it in Game1.getFarm().getShippingBin(farmer))
+				{
+					if (it is not Object o) continue;
+					var model = economyService.GetItemModelFromObject(o);
+					if (model is null) continue;
+					qtyByModel[model] = qtyByModel.TryGetValue(model, out var q) ? q + o.Stack : o.Stack;
+				}
+			}
+
+			foreach (var kv in qtyByModel)
+			{
+				var model = kv.Key;
+				var qty = kv.Value;
+				if (qty <= 0) continue;
+
+				var startSupply = model.Supply;
+				decimal sum = 0m;
+				for (int i = 1; i <= qty; i++)
+					sum += model.GetMultiplierAtSupply(startSupply + i);
+
+				var avg = sum / qty;
+				model.SetOneNightOverrideMultiplier(avg);
+			}
 		}
-			
+
 		foreach (var farmer in farmers)
 		{
 			foreach (var item in Game1.getFarm().getShippingBin(farmer).Where(item => item is Object))
 			{
-				// don't notify as entire economy will be synchronized at the start of the day
 				economyService.AdjustSupply(item as Object, item.Stack, false);
 			}
 		}

--- a/FerngillSimpleEconomy/handlers/DayEndHandler.cs
+++ b/FerngillSimpleEconomy/handlers/DayEndHandler.cs
@@ -1,5 +1,4 @@
-﻿// DayEndHandler.cs
-using fse.core.actions;
+﻿using fse.core.actions;
 using fse.core.helpers;
 using fse.core.models;
 using fse.core.services;
@@ -11,22 +10,31 @@ using static fse.core.models.ConfigModel;
 
 namespace fse.core.handlers;
 
+internal sealed class PendingAdjustSave {
+	public Dictionary<string, int> Counts { get; set; } = new();
+	public long ApplyOnDaysPlayed { get; set; }
+}
+
 public class DayEndHandler(
 		IModHelper helper,
 		IMonitor monitor,
 		IEconomyService economyService
 ) : IHandler {
 
-	private readonly Dictionary<string, int> _pendingAdjust = new();
+	private const string SaveKey = "fse.pending.adjust";
+	internal static readonly Dictionary<string, int> PendingAdjust = new();
 
 	public void Register()
 	{
 		helper.Events.GameLoop.DayEnding += (_, _) =>
-				SafeAction.Run(GameLoopOnDayEnding, monitor, nameof(GameLoopOnDayEnding));
+			SafeAction.Run(GameLoopOnDayEnding, monitor, nameof(GameLoopOnDayEnding));
 
 		helper.Events.GameLoop.DayStarted += (_, _) =>
-				SafeAction.Run(OnDayStarted, monitor, nameof(OnDayStarted));
+			SafeAction.Run(OnDayStarted, monitor, nameof(OnDayStarted));
 	}
+
+	private void SavePending()
+				=> helper.Data.WriteSaveData(SaveKey, new PendingAdjustSave { Counts = new(PendingAdjust) });
 
 	private void GameLoopOnDayEnding()
 	{
@@ -37,7 +45,10 @@ public class DayEndHandler(
 		if (!Game1.player.team.useSeparateWallets.Value)
 			farmers = [farmers.First()];
 
-		foreach (var farmer in farmers) {
+		PendingAdjust.Clear();
+
+		foreach (var farmer in farmers)
+		{
 			foreach (var item in Game1.getFarm().getShippingBin(farmer))
 			{
 				if (item is not Object o) continue;
@@ -48,8 +59,7 @@ public class DayEndHandler(
 					if (model is null) continue;
 
 					// Add Shipped Items (via Shipping Bin)
-					_pendingAdjust[model.ObjectId] =
-							_pendingAdjust.TryGetValue(model.ObjectId, out var q) ? q + o.Stack : o.Stack;
+					PendingAdjust[model.ObjectId] = PendingAdjust.TryGetValue(model.ObjectId, out var q) ? q + o.Stack : o.Stack;
 				}
 				else
 				{
@@ -59,20 +69,33 @@ public class DayEndHandler(
 			}
 		}
 
+		// Persist so Exit or Crash won’t lose it
+		if (PendingAdjust.Count > 0)
+		{
+			SavePending();
+		}
+
 		economyService.HandleDayEnd(new DayModel(Game1.year, SeasonHelper.GetCurrentSeason(), Game1.dayOfMonth));
 	}
 
 	private void OnDayStarted()
 	{
-		// Add "Supply" to Shipped Items (via Shipping Bin)
-		if (_pendingAdjust.Count > 0)
+		var saved = helper.Data.ReadSaveData<PendingAdjustSave>(SaveKey);
+		if (saved is not null && saved.Counts.Count > 0 && saved.ApplyOnDaysPlayed == Game1.stats.DaysPlayed)
 		{
-			foreach (var (objectId, qty) in _pendingAdjust)
+			foreach (var (objectId, qty) in saved.Counts)
+			{
+				PendingAdjust[objectId] = qty;
+			}
+		}
+
+		// Add "Supply" to Shipped Items (via Shipping Bin)
+		if (PendingAdjust.Count > 0)
+		{
+			foreach (var (objectId, qty) in PendingAdjust)
 			{
 				economyService.AdjustSupply(new Object(objectId, 1), qty, notifyPeers: false);
 			}
-
-			_pendingAdjust.Clear();
 		}
 
 		economyService.AdvanceOneDay();

--- a/FerngillSimpleEconomy/models/ConfigModel.cs
+++ b/FerngillSimpleEconomy/models/ConfigModel.cs
@@ -30,6 +30,9 @@ public class ConfigModel
 	public UpdateFrequency DeltaUpdateFrequency { get; set; } = UpdateFrequency.Seasonally;
 	public int CustomSupplyUpdateFrequency { get; set; } = 112;
 	public int CustomDeltaUpdateFrequency { get; set; } = 28;
+	public enum PricingMode { Instant, Batch }
+	public PricingMode ShippingPricingMode { get; set; } = PricingMode.Instant;
+	public PricingMode ShopPricingMode { get; set; } = PricingMode.Instant;
 
 	public List<int> ValidCategories { get; set; } =
 	[

--- a/FerngillSimpleEconomy/patches/ObjectPatches.cs
+++ b/FerngillSimpleEconomy/patches/ObjectPatches.cs
@@ -1,6 +1,11 @@
 ﻿using fse.core.actions;
+using fse.core.models;
 using HarmonyLib;
+using Object = StardewValley.Object;
 using StardewValley;
+using StardewValley.Menus;
+using System;
+using static fse.core.models.ConfigModel;
 
 namespace fse.core.patches
 {
@@ -8,8 +13,20 @@ namespace fse.core.patches
 	{
 		public static void SellToStoreSalePricePostFix(Object __instance, ref int __result)
 		{
-			var basePrice = __result;
-			__result = SafeAction.Run(() => EconomyService.GetPrice(__instance, basePrice), __result, Monitor);
+			// Instant Price
+			if (Game1.activeClickableMenu is ShopMenu &&
+					ConfigModel.Instance.ShopPricingMode == PricingMode.Instant) {
+				var model = EconomyService.GetItemModelFromObject(__instance);
+				if (model != null) {
+					int basePrice = __result;
+					decimal mult = model.GetMultiplierAtSupply(model.Supply + 1);
+					__result = (int)Math.Round(basePrice * mult, 0, MidpointRounding.ToEven);
+					return;
+				}
+			}
+
+			int baseP = __result;
+			__result = SafeAction.Run(() => EconomyService.GetPrice(__instance, baseP), baseP, Monitor);
 		}
 
 		public override void Register(Harmony harmony)

--- a/FerngillSimpleEconomy/patches/ObjectPatches.cs
+++ b/FerngillSimpleEconomy/patches/ObjectPatches.cs
@@ -1,29 +1,35 @@
 ﻿using fse.core.actions;
 using fse.core.models;
 using HarmonyLib;
-using Object = StardewValley.Object;
 using StardewValley;
 using StardewValley.Menus;
 using System;
 using static fse.core.models.ConfigModel;
 using Econ = fse.core.services.EconomyService;
+using Object = StardewValley.Object;
 
-namespace fse.core.patches
-{
-	public class ObjectPatches : SelfRegisteringPatches
-	{
-
+namespace fse.core.patches {
+	public class ObjectPatches : SelfRegisteringPatches {
 		public static void SellToStoreSalePricePostFix(Object __instance, ref int __result) {
 			if (Econ.BypassPricePatch) return;
-			if (Game1.activeClickableMenu is ShopMenu)
-				return;
 
+			if (Game1.activeClickableMenu is ShopMenu &&
+					ConfigModel.Instance.ShopPricingMode == PricingMode.Instant) {
+				var model = EconomyService.GetItemModelFromObject(__instance);
+				if (model != null) {
+					int baseUnit = __result; // Vanilla Base Unit
+					decimal mNext = model.GetMultiplierAtSupply(model.Supply + 1); // Next Unit Multiplier
+					__result = (int)Math.Round(baseUnit * mNext, 0, MidpointRounding.ToEven);
+					return;
+				}
+			}
+
+			// Non-Shop: Apply Normal FSE Pricing
 			int baseP = __result;
 			__result = SafeAction.Run(() => EconomyService.GetPrice(__instance, baseP), baseP, Monitor);
 		}
 
-		public override void Register(Harmony harmony)
-		{
+		public override void Register(Harmony harmony) {
 			harmony.Patch(
 				AccessTools.Method(typeof(Object), nameof(Object.sellToStorePrice)),
 				postfix: new HarmonyMethod(typeof(ObjectPatches), nameof(SellToStoreSalePricePostFix))

--- a/FerngillSimpleEconomy/patches/ObjectPatches.cs
+++ b/FerngillSimpleEconomy/patches/ObjectPatches.cs
@@ -11,9 +11,7 @@ using Object = StardewValley.Object;
 namespace fse.core.patches {
 	public class ObjectPatches : SelfRegisteringPatches {
 		public static void SellToStoreSalePricePostFix(Object __instance, ref int __result) {
-			if (Econ.BypassPricePatch) return;
-
-			// Non-Shop: Apply Normal FSE Pricing
+			// FSE Pricing
 			var basePrice = __result;
 			if (ConfigModel.Instance.ShopPricingMode == PricingMode.Instant)
 			{

--- a/FerngillSimpleEconomy/patches/ObjectPatches.cs
+++ b/FerngillSimpleEconomy/patches/ObjectPatches.cs
@@ -6,24 +6,17 @@ using StardewValley;
 using StardewValley.Menus;
 using System;
 using static fse.core.models.ConfigModel;
+using Econ = fse.core.services.EconomyService;
 
 namespace fse.core.patches
 {
 	public class ObjectPatches : SelfRegisteringPatches
 	{
-		public static void SellToStoreSalePricePostFix(Object __instance, ref int __result)
-		{
-			// Instant Price
-			if (Game1.activeClickableMenu is ShopMenu &&
-					ConfigModel.Instance.ShopPricingMode == PricingMode.Instant) {
-				var model = EconomyService.GetItemModelFromObject(__instance);
-				if (model != null) {
-					int basePrice = __result;
-					decimal mult = model.GetMultiplierAtSupply(model.Supply + 1);
-					__result = (int)Math.Round(basePrice * mult, 0, MidpointRounding.ToEven);
-					return;
-				}
-			}
+
+		public static void SellToStoreSalePricePostFix(Object __instance, ref int __result) {
+			if (Econ.BypassPricePatch) return;
+			if (Game1.activeClickableMenu is ShopMenu)
+				return;
 
 			int baseP = __result;
 			__result = SafeAction.Run(() => EconomyService.GetPrice(__instance, baseP), baseP, Monitor);

--- a/FerngillSimpleEconomy/patches/ShopMenuPatches.cs
+++ b/FerngillSimpleEconomy/patches/ShopMenuPatches.cs
@@ -25,14 +25,9 @@ namespace fse.core.patches {
 			var model = EconomyService.GetItemModelFromObject(obj);
 			if (model is null) return;
 
-			// Vanilla base Unit Price
-			int baseUnit;
-			try { Econ.BypassPricePatch = true; baseUnit = obj.sellToStorePrice(); }
-			finally { Econ.BypassPricePatch = false; }
-
-			int vanillaTotal = sell_unit_price * quantity;
+			int currentTotal = sell_unit_price * quantity;
 			int wantedTotal = EconomyService.GetInstantTotal(obj);
-			int delta = wantedTotal - vanillaTotal;
+			int delta = wantedTotal - currentTotal;
 			if (delta != 0) Game1.player.Money += delta;
 
 			EconomyService.AdjustSupply(obj, quantity);

--- a/FerngillSimpleEconomy/patches/ShopMenuPatches.cs
+++ b/FerngillSimpleEconomy/patches/ShopMenuPatches.cs
@@ -17,20 +17,25 @@ namespace fse.core.patches {
 	public class ShopMenuPatches : SelfRegisteringPatches {
 		// Correct Payout
 		public static void AddBuybackItem_Postfix(ShopMenu __instance, ISalable sold_item, int sell_unit_price) {
-			if (ConfigModel.Instance.ShopPricingMode != PricingMode.Instant) return;
 			if (sold_item is not Object obj) return;
 
-			int quantity = obj.Stack;
+			if (ConfigModel.Instance.ShopPricingMode == PricingMode.Instant) {
+				int quantity = obj.Stack;
 
-			var model = EconomyService.GetItemModelFromObject(obj);
-			if (model is null) return;
+				var model = EconomyService.GetItemModelFromObject(obj);
+				if (model is null) return;
 
-			int currentTotal = sell_unit_price * quantity;
-			int wantedTotal = EconomyService.GetInstantTotal(obj);
-			int delta = wantedTotal - currentTotal;
-			if (delta != 0) Game1.player.Money += delta;
+				int currentTotal = sell_unit_price * quantity;
+				int wantedTotal = EconomyService.GetInstantTotal(obj);
+				int delta = wantedTotal - currentTotal;
+				if (delta != 0) Game1.player.Money += delta;
 
-			EconomyService.AdjustSupply(obj, quantity);
+				EconomyService.AdjustSupply(obj, quantity);
+			}
+			else
+			{
+				EconomyService.AdjustSupply(obj, obj.Stack);
+			}
 		}
 
 		public static void BuyBuybackItem_Postfix(ISalable bought_item, int price, int stack) {

--- a/FerngillSimpleEconomy/patches/ShopMenuPatches.cs
+++ b/FerngillSimpleEconomy/patches/ShopMenuPatches.cs
@@ -1,90 +1,117 @@
-﻿using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
-using fse.core.models;
+﻿using fse.core.models;
 using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
 using StardewValley.Menus;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using static fse.core.models.ConfigModel;
+using Econ = fse.core.services.EconomyService;
 using Object = StardewValley.Object;
 
-namespace fse.core.patches
-{
-	public class ShopMenuPatches : SelfRegisteringPatches
-	{
-		//Prefix as the number of sold stacks is modified in the original function
-		public static bool AddBuyBackItemPreFix(ISalable sold_item, int sell_unit_price, int stack)
-		{
-			if (sold_item is Object soldObject)
-			{
-				EconomyService.AdjustSupply(soldObject, stack);
-			}
+namespace fse.core.patches {
+	public class ShopMenuPatches : SelfRegisteringPatches {
+		private static int MarginalTotal(ItemModel model, int qty, int baseUnit) {
+			if (qty <= 0) return 0;
 
-			return true;
+			int s = model.Supply;
+			int cap = ConfigModel.Instance.MaxCalculatedSupply;
+
+			int k = Math.Max(0, Math.Min(qty, cap - s));
+			decimal mStart = model.GetMultiplierAtSupply(s + 1);
+			decimal mEnd = model.GetMultiplierAtSupply(s + k);
+			decimal sumLinear = k * (mStart + mEnd) / 2m;
+
+			int tail = qty - k; // Past Cap -> flat at MinPercentage
+			decimal sumTail = tail * ConfigModel.Instance.MinPercentage;
+
+			decimal totalMult = sumLinear + sumTail;
+			return (int)Math.Round(baseUnit * totalMult, 0, MidpointRounding.ToEven);
 		}
 
-		public static void BuyBuybackItemPostFix(ISalable bought_item, int price, int stack)
-		{
-			if (bought_item is Object boughtObject)
-			{
-				EconomyService.AdjustSupply(boughtObject, -stack);
+		// Correct Payout
+		public static void AddBuybackItem_Postfix(ShopMenu __instance, ISalable sold_item, int sell_unit_price, int stack) {
+			if (ConfigModel.Instance.ShopPricingMode != PricingMode.Instant) return;
+			if (sold_item is not Object obj) return;
+
+			// Resolve Sold Quantity (may be 0 in 1.6)
+			int qty = stack;
+			if (qty <= 0) qty = obj.Stack;
+
+			if (qty <= 0) {
+				string[] fields = { "buyBackItemsToSell", "buyBackItems", "buyBackItemsForSale" };
+				foreach (var fname in fields) {
+					var fi = AccessTools.Field(typeof(ShopMenu), fname);
+					if (fi == null) continue;
+					if (fi.GetValue(__instance) is IList list && list.Count > 0) {
+						if (list[list.Count - 1] is Object last && last.ParentSheetIndex == obj.ParentSheetIndex) {
+							qty = last.Stack;
+							break;
+						}
+					}
+				}
 			}
+			if (qty <= 0) return;
+
+			var model = EconomyService.GetItemModelFromObject(obj);
+			if (model is null) return;
+
+			// Vanilla base Unit Price
+			int baseUnit;
+			try { Econ.BypassPricePatch = true; baseUnit = obj.sellToStorePrice(); }
+			finally { Econ.BypassPricePatch = false; }
+
+			int vanillaTotal = sell_unit_price * qty;
+			int wantedTotal = MarginalTotal(model, qty, baseUnit);
+			int delta = wantedTotal - vanillaTotal;
+			if (delta != 0) Game1.player.Money += delta;
+
+			EconomyService.AdjustSupply(obj, qty);
 		}
 
-		public static void DrawSeedInfo(
-			SpriteBatch b,
-			// ReSharper disable once InconsistentNaming
-			ShopMenu shopMenu
-		)
-		{
-			if (shopMenu.forSale == null)
-			{
-				return;
-			}
+		public static void BuyBuybackItem_Postfix(ISalable bought_item, int price, int stack) {
+			if (bought_item is Object o && stack > 0)
+				EconomyService.AdjustSupply(o, -stack);
+		}
 
-			if (!ConfigModel.Instance.EnableShopDisplay)
-			{
-				return;
-			}
+		public static void DrawSeedInfo(SpriteBatch b, ShopMenu shopMenu) {
+			if (shopMenu.forSale == null) return;
+			if (!ConfigModel.Instance.EnableShopDisplay) return;
 
 			var forSaleButtons = shopMenu.forSaleButtons;
 			var forSale = shopMenu.forSale;
 			int currItemIdx = shopMenu.currentItemIndex;
 			int vanillaBtnWidth = shopMenu.width - 32;
-			for (int i = 0; i < forSaleButtons.Count; i++)
-			{
-				if (currItemIdx + i >= forSale.Count)
-				{
-					continue;
-				}
+
+			for (int i = 0; i < forSaleButtons.Count; i++) {
+				if (currItemIdx + i >= forSale.Count) continue;
+
 				ClickableComponent component = forSaleButtons[i];
 				ISalable salable = forSale[currItemIdx + i];
 				Rectangle bounds = component.bounds;
-				if (salable is Object { Category: Object.SeedsCategory } obj && EconomyService.GetItemModelFromSeed(obj.ItemId) is ItemModel model)
-				{
+
+				if (salable is Object { Category: Object.SeedsCategory } obj && EconomyService.GetItemModelFromSeed(obj.ItemId) is ItemModel model) {
 					if (bounds.Width < vanillaBtnWidth)
-					{
 						DrawSupplyBarHelper.DrawSupplyBar(b, bounds.X + 96, component.bounds.Y + 20, bounds.Right - bounds.Width / 5, 30, model);
-					}
 					else
-					{
 						DrawSupplyBarHelper.DrawSupplyBar(b, bounds.Right - 400, component.bounds.Y + 20, bounds.Right - 200, 30, model);
-					}
 				}
 			}
 		}
 
-		public override void Register(Harmony harmony)
-		{
+		public override void Register(Harmony harmony) {
 			harmony.Patch(
 				AccessTools.Method(typeof(ShopMenu), nameof(ShopMenu.AddBuybackItem)),
-				new HarmonyMethod(typeof(ShopMenuPatches), nameof(AddBuyBackItemPreFix))
+				postfix: new HarmonyMethod(typeof(ShopMenuPatches), nameof(AddBuybackItem_Postfix))
 			);
 
 			harmony.Patch(
 				AccessTools.Method(typeof(ShopMenu), nameof(ShopMenu.BuyBuybackItem)),
-				postfix: new HarmonyMethod(typeof(ShopMenuPatches), nameof(BuyBuybackItemPostFix))
+				postfix: new HarmonyMethod(typeof(ShopMenuPatches), nameof(BuyBuybackItem_Postfix))
 			);
 
 			harmony.Patch(
@@ -93,22 +120,19 @@ namespace fse.core.patches
 			);
 		}
 
-		public static IEnumerable<CodeInstruction> ShopDrawingTranspiler(IEnumerable<CodeInstruction> steps)
-		{
-			using var enumerator = steps.GetEnumerator();
+		public static IEnumerable<CodeInstruction> ShopDrawingTranspiler(IEnumerable<CodeInstruction> steps) {
+			using var e = steps.GetEnumerator();
+			while (e.MoveNext()) {
+				var cur = e.Current;
 
-			while (enumerator.MoveNext())
-			{
-				var current = enumerator.Current;
-
-				if (current.opcode == OpCodes.Ldfld && (FieldInfo)current.operand == AccessTools.Field(typeof(ShopMenu), nameof(ShopMenu.downArrow)))
-				{
+				if (cur.opcode == OpCodes.Ldfld &&
+						(FieldInfo)cur.operand == AccessTools.Field(typeof(ShopMenu), nameof(ShopMenu.downArrow))) {
 					yield return new CodeInstruction(OpCodes.Ldarg_1);
 					yield return new CodeInstruction(OpCodes.Ldarg_0);
 					yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(ShopMenuPatches), nameof(DrawSeedInfo)));
 				}
 
-				yield return enumerator.Current;
+				yield return cur;
 			}
 		}
 	}

--- a/FerngillSimpleEconomy/services/EconomyService.cs
+++ b/FerngillSimpleEconomy/services/EconomyService.cs
@@ -7,6 +7,7 @@ using fse.core.multiplayer;
 using StardewModdingAPI;
 using StardewValley;
 using Object = StardewValley.Object;
+using static fse.core.models.ConfigModel;
 
 namespace fse.core.services;
 
@@ -334,13 +335,15 @@ public class EconomyService(
 		var itemModel = Economy.GetItem(obj);
 		if (itemModel == null)
 		{
-			// monitor.Log($"Could not find item model for {obj.name}", LogLevel.Trace);
 			return;
 		}
 
 		itemModel.Supply += amount;
 
-		// monitor.Log($"Adjusted {obj.name} supply from {prev} to {itemModel.Supply}", LogLevel.Trace);
+		if (ConfigModel.Instance.ShopPricingMode == PricingMode.Instant)
+		{
+			itemModel.UpdateMultiplier();
+		}
 
 		if (notifyPeers)
 		{

--- a/FerngillSimpleEconomy/services/EconomyService.cs
+++ b/FerngillSimpleEconomy/services/EconomyService.cs
@@ -47,6 +47,8 @@ public class EconomyService(
 	public bool Loaded { get; private set; }
 
 	private EconomyModel Economy { get; set; } = new(new Dictionary<int, Dictionary<string, ItemModel>>());
+	
+	public static bool BypassPricePatch = false;
 
 	public void OnLoaded()
 	{
@@ -434,4 +436,14 @@ public class EconomyService(
 
 	private static int RoundDouble(double d) => (int)Math.Round(d, 0, MidpointRounding.ToEven);
 	private static int RoundDecimal(decimal d) => (int)Math.Round(d, 0, MidpointRounding.ToEven);
+
+ public int GetVanillaSellPrice(Object obj) {
+	try {
+	 BypassPricePatch = true;
+	 return obj.sellToStorePrice();
+	}
+	finally {
+	 BypassPricePatch = false;
+	}
+ }
 }

--- a/FerngillSimpleEconomy/services/GenericConfigMenuService.cs
+++ b/FerngillSimpleEconomy/services/GenericConfigMenuService.cs
@@ -9,6 +9,7 @@ using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
 using Object = StardewValley.Object;
+using static fse.core.models.ConfigModel;
 
 namespace fse.core.services;
 
@@ -281,6 +282,34 @@ public class GenericConfigMenuService(
 			setValue: val => ConfigModel.Instance.CustomDeltaUpdateFrequency = val,
 			min: 1
 		);
+
+		configMenu.AddSectionTitle(mod: manifest, text: () => "Pricing Mode");
+
+		string[] modes = Enum.GetNames(typeof(PricingMode));
+
+		configMenu.AddTextOption(
+				mod: manifest,
+				name: () => "Shipping Bin Pricing Mode",
+				getValue: () => ConfigModel.Instance.ShippingPricingMode.ToString(),
+				setValue: v => {
+					if (Enum.TryParse<PricingMode>(v, out var m))
+						ConfigModel.Instance.ShippingPricingMode = m;
+				},
+				allowedValues: modes,
+				formatAllowedValue: s => s
+		);
+
+		//configMenu.AddTextOption(
+		//		mod: manifest,
+		//		name: () => "Shop Pricing Mode",
+		//		getValue: () => ConfigModel.Instance.ShopPricingMode.ToString(),
+		//		setValue: v => {
+		//			if (Enum.TryParse<PricingMode>(v, out var m))
+		//				ConfigModel.Instance.ShopPricingMode = m;
+		//		},
+		//		allowedValues: modes,
+		//		formatAllowedValue: s => s
+		//);
 	}
 
 	private void PopulateMenuPage(IGenericModConfigMenuApi configMenu)

--- a/FerngillSimpleEconomy/services/GenericConfigMenuService.cs
+++ b/FerngillSimpleEconomy/services/GenericConfigMenuService.cs
@@ -299,17 +299,17 @@ public class GenericConfigMenuService(
 				formatAllowedValue: s => s
 		);
 
-		//configMenu.AddTextOption(
-		//		mod: manifest,
-		//		name: () => "Shop Pricing Mode",
-		//		getValue: () => ConfigModel.Instance.ShopPricingMode.ToString(),
-		//		setValue: v => {
-		//			if (Enum.TryParse<PricingMode>(v, out var m))
-		//				ConfigModel.Instance.ShopPricingMode = m;
-		//		},
-		//		allowedValues: modes,
-		//		formatAllowedValue: s => s
-		//);
+		configMenu.AddTextOption(
+				mod: manifest,
+				name: () => "Shop Pricing Mode",
+				getValue: () => ConfigModel.Instance.ShopPricingMode.ToString(),
+				setValue: v => {
+					if (Enum.TryParse<PricingMode>(v, out var m))
+						ConfigModel.Instance.ShopPricingMode = m;
+				},
+				allowedValues: modes,
+				formatAllowedValue: s => s
+		);
 	}
 
 	private void PopulateMenuPage(IGenericModConfigMenuApi configMenu)


### PR DESCRIPTION
Selling in Store or via Shipping Bin instantly calculates Total Price and Supply, like in #33 
It also adds 2 Dropdowns to Config (under "Frequency" Tab) with:
- Batch -> Previous Default Setting
- Instant -> New Mode added with my Changes, I set this as Default

It also calculates Total Price after hovering on Item (but with ~99% accuracy, because of rounding)

<img width="1135" height="258" alt="Instant Pricing #1" src="https://github.com/user-attachments/assets/9449170c-e92d-47ce-a938-9b4d08f5286f" />
<img width="1700" height="822" alt="Instant Pricing #2" src="https://github.com/user-attachments/assets/588b14e7-b580-43d8-94ad-9ea75c5a98e2" />
<img width="688" height="497" alt="Instant Pricing #3" src="https://github.com/user-attachments/assets/56d1f1bd-99cb-466b-8858-d25dd078741e" />
<img width="1741" height="768" alt="Instant Pricing #4" src="https://github.com/user-attachments/assets/82aef513-aa42-471a-9cc6-d64642b14d0b" />
<img width="1695" height="797" alt="Instant Pricing #5" src="https://github.com/user-attachments/assets/b93a3ad4-c625-4ad2-86af-0d692870a6df" />
<img width="622" height="483" alt="Instant Pricing #6" src="https://github.com/user-attachments/assets/19b8100b-e7b6-4b8f-82ad-80af60b9f12f" />
<img width="1708" height="832" alt="Instant Pricing #7" src="https://github.com/user-attachments/assets/5ba56c21-3839-46af-a607-e085aecc5202" />
